### PR TITLE
Interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,3 +826,25 @@ request : {
 }
 response : 204 No Content
 ```
+
+- 서버 상태
+
+  - GET /state/
+  - response
+    - period: 서버의 현재 기간
+    
+| period | 기간        |
+|--------|-----------|
+| 0      | 수강신청 시작 전 |
+| 1      | 장바구니 신청   |
+| 2      | 장바구니 확정   |
+| 3      | 수강신청      |
+| 4      | 개강        |
+
+
+```
+request : {}
+response : {
+	"period": 1
+}
+```

--- a/team8_server/serializers.py
+++ b/team8_server/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from team8_server.models import ServerState
+
+
+class ServerStateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ServerState
+        fields = ['period']

--- a/team8_server/urls.py
+++ b/team8_server/urls.py
@@ -17,7 +17,7 @@ from django.contrib import admin
 from django.urls import path, include
 
 from snu_student import views
-from .views import change_period, confirm
+from .views import change_period, confirm, StateDetail
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -26,6 +26,7 @@ urlpatterns = [
     path('interest/', views.InterestCourseAPIView.as_view()),
     path('cart/', views.CartCourseAPIView.as_view()),
     path('registered/', views.RegisteredCourseAPIView.as_view()),
+    path('state/', StateDetail.as_view()),
     path('test/period/', change_period),
     path('test/confirm/', confirm),
 ]

--- a/team8_server/views.py
+++ b/team8_server/views.py
@@ -1,11 +1,13 @@
 from django.db.models import Count, F
 from django.http import HttpResponse
+from rest_framework import generics
 
 from snu_course.models import Course
 from snu_student.models import UserToCourse
 from team8_server.constants import CourseSorts
 from .constants import Periods
 from .models import ServerState
+from .serializers import ServerStateSerializer
 
 
 def change_period(request):
@@ -32,3 +34,11 @@ def confirm(request):
     queryset = Course.objects.filter(id__in=pending_courses)
     queryset.update(pending=True)
     return HttpResponse(f"{count}개의 강좌가 장바구니 보류강좌로 전환되었습니다.")
+
+
+class StateDetail(generics.RetrieveAPIView):
+    serializer_class = ServerStateSerializer
+    queryset = ServerState.objects.all()
+
+    def get_object(self):
+        return self.queryset.first()


### PR DESCRIPTION
1. 서버에 기간이 적용되어 장바구니 추가는 장바구니 기간에만, 수강신청은 수강신청 기간에만 가능하도록 변경되었습니다. (POST 요청에만 해당)
GET /state/ 로 서버의 현재 기간을 받아올 수 있습니다. 자세한 내용은 리드미 참조 바랍니다.

2. 강좌에 장바구니 보류 여부를 나타내는 boolean 필드 pending이 추가되었습니다.

3. 강좌에 현재 관심강좌로 담은 인원수를 나타내는 integer 필드 interest가 추가되었습니다.

4. 프론트 개발 편의를 위해 다음 기능들을 임시로 API endpoint에 추가하였습니다.
웹브라우저로 https://snu-sugang.o-r.kr/test/period/ 에 접속하여 서버의 기간을 변경할 수 있습니다.
웹브라우저로 https://snu-sugang.o-r.kr/test/confirm/ 에 접속하여 장바구니 확정을 진행할 수 있습니다.
장바구니에 담은 인원수가 정원 이하인 강좌는 자동으로 수강신청됩니다.
장바구니에 담은 인원수가 정원보다 큰 강좌는 pending이 true로 바뀝니다.